### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix partial file leakage on decryption failure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-02 - Delete Output File on Decryption Failure
+**Vulnerability:** File decryption process didn't clean up the partially written output file when a CryptographicException occurred due to chunk authentication failure.
+**Learning:** Even though the stream disposal happens after `catch` or handles exception exits, if we exit with an exception, the partially written file was left on disk. This could leave potentially sensitive partially decrypted data exposed or leave an invalid file on disk.
+**Prevention:** Whenever decrypting to a file in chunks and verifying authentication, always catch the authentication failure and safely delete the resulting output file to avoid leaving partial or tampered data on disk.

--- a/encryption cypher app/CryptoEngineBlueprint.cs
+++ b/encryption cypher app/CryptoEngineBlueprint.cs
@@ -696,6 +696,7 @@ namespace encryption_cypher_app
             catch (CryptographicException)
             {
                 // wrong key or tampering (chunk auth failure)
+                try { File.Delete(outputPath); } catch { }
                 return false;
             }
             finally


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: When file decryption fails due to a `CryptographicException` (e.g., from an incorrect key or chunk tampering), the application left the partially written `outputPath` file on disk.
🎯 Impact: This could expose partially decrypted data if the file was modified, or at least leave behind invalid/corrupted files that confuse the user.
🔧 Fix: Wrapped the `catch (CryptographicException)` block in `DecryptFile` with a safe `try { File.Delete(outputPath); } catch { }` to securely delete the partial file and ensure we fail securely.
✅ Verification: Build the app via `dotnet build -p:EnableWindowsTargeting=true`. Attempt to decrypt a file with the wrong key or tamper with an encrypted file. Observe that the decrypted file does not persist on disk.

---
*PR created automatically by Jules for task [4927538677482278776](https://jules.google.com/task/4927538677482278776) started by @UnicornGod117*