### PR TITLE
🎨 Palette: Add visual feedback to copy button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Visual Feedback for Copy Actions
+**Learning:** Users lack confidence when copying data without visual feedback. Temporarily changing button text (e.g., 'Copied!') is a simple, effective pattern for clipboard actions.
+**Action:** Always provide immediate visual confirmation when implementing clipboard interactions.

--- a/encryption cypher app/Form1.cs
+++ b/encryption cypher app/Form1.cs
@@ -108,10 +108,18 @@ namespace encryption_cypher_app
 
         }
 
-        private void encryptioncopybutton_Click(object sender, EventArgs e)
+        private async void encryptioncopybutton_Click(object sender, EventArgs e)
         {
+            if (encryptioncopybutton.Text == "Copied!") return;
             string encryptionoutput = TextBoxEncryptOutput.Text;
-            Clipboard.SetText(encryptionoutput);
+            if (!string.IsNullOrEmpty(encryptionoutput))
+            {
+                Clipboard.SetText(encryptionoutput);
+                string originalText = encryptioncopybutton.Text;
+                encryptioncopybutton.Text = "Copied!";
+                await Task.Delay(1500);
+                encryptioncopybutton.Text = originalText;
+            }
         }
 
         private void decryptionpastebutton_Click(object sender, EventArgs e)


### PR DESCRIPTION
💡 What: Added visual feedback to the copy button. It now temporarily displays "Copied!" after successfully copying text, and reverts back to "Copy". Also, added an `!string.IsNullOrEmpty()` check to safely handle cases when the text box is empty, preventing a WinForms `ArgumentNullException` from `Clipboard.SetText`.

🎯 Why: Users lack confidence when copying data without visual feedback. This simple enhancement makes the interaction more pleasant and confirms that the action succeeded.

📸 Before/After: Visual text change from "Copy" to "Copied!" for 1.5 seconds.

♿ Accessibility: Gives clear immediate confirmation of an action which benefits all users.

---
*PR created automatically by Jules for task [8448628630534884671](https://jules.google.com/task/8448628630534884671) started by @UnicornGod117*