### PR TITLE
Fix UI overlaps and reorganize Form2 layout

### DIFF
--- a/changelog/palette.md
+++ b/changelog/palette.md
@@ -5,3 +5,7 @@
 ## 2026-04-06 - [Asynchronous Progress Feedback]
 **Learning:** Performing long-running file operations synchronously on the main thread causes the UI to become unresponsive, leading to a poor user experience. Providing real-time progress feedback through a progress bar and status label significantly improves perceived performance and user confidence.
 **Action:** Always offload heavy file I/O and cryptographic tasks to background threads (e.g., using Task.Run) and use IProgress<T> to safely update the UI from background operations. Disable UI controls during the operation to prevent re-entrancy and verify !IsDisposed before interacting with UI components after an await.
+
+## 2026-04-06 - [Logical UI Grouping and Clearance]
+**Learning:** Cluttered UI with overlapping controls (especially error labels) leads to poor accessibility and user confusion. Organizing tools into logical columns and ensuring enough vertical clearance for dynamic labels (like error text) improves visual hierarchy.
+**Action:** Group related controls (e.g., Key Generation vs File Tools) into distinct layout columns and provide at least 30-40 pixels of vertical clearance between input rows to accommodate dynamic error labels without overlapping subsequent controls.

--- a/encryption cypher app/Form1.Designer.cs
+++ b/encryption cypher app/Form1.Designer.cs
@@ -80,7 +80,7 @@
             // 
             // keybox2
             // 
-            keybox2.Location = new Point(274, 187);
+            keybox2.Location = new Point(274, 227);
             keybox2.Name = "keybox2";
             keybox2.Size = new Size(467, 31);
             keybox2.TabIndex = 2;
@@ -90,7 +90,7 @@
             // 
             keylabel2.AutoSize = true;
             keylabel2.ForeColor = SystemColors.Control;
-            keylabel2.Location = new Point(470, 159);
+            keylabel2.Location = new Point(470, 199);
             keylabel2.Name = "keylabel2";
             keylabel2.Size = new Size(55, 25);
             keylabel2.TabIndex = 3;
@@ -100,7 +100,7 @@
             // Encryptbutton
             // 
             Encryptbutton.ForeColor = SystemColors.Desktop;
-            Encryptbutton.Location = new Point(180, 462);
+            Encryptbutton.Location = new Point(180, 502);
             Encryptbutton.Name = "Encryptbutton";
             Encryptbutton.Size = new Size(129, 34);
             Encryptbutton.TabIndex = 4;
@@ -111,7 +111,7 @@
             // Decryptbutton
             // 
             Decryptbutton.ForeColor = SystemColors.Desktop;
-            Decryptbutton.Location = new Point(1159, 462);
+            Decryptbutton.Location = new Point(1159, 502);
             Decryptbutton.Name = "Decryptbutton";
             Decryptbutton.Size = new Size(132, 34);
             Decryptbutton.TabIndex = 5;
@@ -123,7 +123,7 @@
             // 
             Decryptlabel.AutoSize = true;
             Decryptlabel.ForeColor = SystemColors.Control;
-            Decryptlabel.Location = new Point(1052, 312);
+            Decryptlabel.Location = new Point(1052, 352);
             Decryptlabel.Name = "Decryptlabel";
             Decryptlabel.Size = new Size(375, 25);
             Decryptlabel.TabIndex = 6;
@@ -133,7 +133,7 @@
             // 
             Encryptlabel.AutoSize = true;
             Encryptlabel.ForeColor = SystemColors.Control;
-            Encryptlabel.Location = new Point(81, 312);
+            Encryptlabel.Location = new Point(81, 352);
             Encryptlabel.Name = "Encryptlabel";
             Encryptlabel.Size = new Size(371, 25);
             Encryptlabel.TabIndex = 7;
@@ -141,7 +141,7 @@
             // 
             // TextBoxDecryptionInput
             // 
-            TextBoxDecryptionInput.Location = new Point(1052, 353);
+            TextBoxDecryptionInput.Location = new Point(1052, 393);
             TextBoxDecryptionInput.Multiline = true;
             TextBoxDecryptionInput.Name = "TextBoxDecryptionInput";
             TextBoxDecryptionInput.Size = new Size(359, 76);
@@ -150,7 +150,7 @@
             // 
             // TextboxEncryptioninput
             // 
-            TextboxEncryptioninput.Location = new Point(81, 353);
+            TextboxEncryptioninput.Location = new Point(81, 393);
             TextboxEncryptioninput.Multiline = true;
             TextboxEncryptioninput.Name = "TextboxEncryptioninput";
             TextboxEncryptioninput.Size = new Size(359, 76);
@@ -159,7 +159,7 @@
             // 
             // TextBoxDecryptOutput
             // 
-            TextBoxDecryptOutput.Location = new Point(1052, 562);
+            TextBoxDecryptOutput.Location = new Point(1052, 602);
             TextBoxDecryptOutput.Multiline = true;
             TextBoxDecryptOutput.Name = "TextBoxDecryptOutput";
             TextBoxDecryptOutput.ReadOnly = true;
@@ -169,7 +169,7 @@
             // 
             // TextBoxEncryptOutput
             // 
-            TextBoxEncryptOutput.Location = new Point(81, 568);
+            TextBoxEncryptOutput.Location = new Point(81, 608);
             TextBoxEncryptOutput.Multiline = true;
             TextBoxEncryptOutput.Name = "TextBoxEncryptOutput";
             TextBoxEncryptOutput.ReadOnly = true;
@@ -180,7 +180,7 @@
             // 
             decryptedlabel.AutoSize = true;
             decryptedlabel.ForeColor = SystemColors.Control;
-            decryptedlabel.Location = new Point(1159, 533);
+            decryptedlabel.Location = new Point(1159, 573);
             decryptedlabel.Name = "decryptedlabel";
             decryptedlabel.Size = new Size(132, 25);
             decryptedlabel.TabIndex = 12;
@@ -190,7 +190,7 @@
             // 
             Encryptedlabel.AutoSize = true;
             Encryptedlabel.ForeColor = SystemColors.Control;
-            Encryptedlabel.Location = new Point(180, 533);
+            Encryptedlabel.Location = new Point(180, 573);
             Encryptedlabel.Name = "Encryptedlabel";
             Encryptedlabel.Size = new Size(129, 25);
             Encryptedlabel.TabIndex = 13;
@@ -213,7 +213,7 @@
             // 
             invalidformatlabelkey2.AutoSize = true;
             invalidformatlabelkey2.ForeColor = Color.Red;
-            invalidformatlabelkey2.Location = new Point(299, 221);
+            invalidformatlabelkey2.Location = new Point(299, 261);
             invalidformatlabelkey2.Name = "invalidformatlabelkey2";
             invalidformatlabelkey2.Size = new Size(393, 25);
             invalidformatlabelkey2.TabIndex = 15;
@@ -224,7 +224,7 @@
             // encryptioncopybutton
             // 
             encryptioncopybutton.ForeColor = SystemColors.Desktop;
-            encryptioncopybutton.Location = new Point(446, 783);
+            encryptioncopybutton.Location = new Point(446, 823);
             encryptioncopybutton.Name = "encryptioncopybutton";
             encryptioncopybutton.Size = new Size(112, 34);
             encryptioncopybutton.TabIndex = 16;
@@ -235,7 +235,7 @@
             // decryptionpastebutton
             // 
             decryptionpastebutton.ForeColor = SystemColors.Desktop;
-            decryptionpastebutton.Location = new Point(916, 349);
+            decryptionpastebutton.Location = new Point(916, 389);
             decryptionpastebutton.Name = "decryptionpastebutton";
             decryptionpastebutton.Size = new Size(112, 34);
             decryptionpastebutton.TabIndex = 17;
@@ -247,7 +247,7 @@
             // 
             pasteerror.AutoSize = true;
             pasteerror.ForeColor = Color.Red;
-            pasteerror.Location = new Point(894, 388);
+            pasteerror.Location = new Point(894, 428);
             pasteerror.Name = "pasteerror";
             pasteerror.Size = new Size(152, 25);
             pasteerror.TabIndex = 18;
@@ -258,7 +258,7 @@
             // 
             keylabel4.AutoSize = true;
             keylabel4.ForeColor = SystemColors.Control;
-            keylabel4.Location = new Point(977, 159);
+            keylabel4.Location = new Point(977, 199);
             keylabel4.Name = "keylabel4";
             keylabel4.Size = new Size(55, 25);
             keylabel4.TabIndex = 22;
@@ -267,7 +267,7 @@
             // 
             // keybox4
             // 
-            keybox4.Location = new Point(781, 187);
+            keybox4.Location = new Point(781, 227);
             keybox4.Name = "keybox4";
             keybox4.Size = new Size(467, 31);
             keybox4.TabIndex = 21;
@@ -296,7 +296,7 @@
             // 
             invalidformatlabelkey4.AutoSize = true;
             invalidformatlabelkey4.ForeColor = Color.Red;
-            invalidformatlabelkey4.Location = new Point(818, 221);
+            invalidformatlabelkey4.Location = new Point(818, 261);
             invalidformatlabelkey4.Name = "invalidformatlabelkey4";
             invalidformatlabelkey4.Size = new Size(393, 25);
             invalidformatlabelkey4.TabIndex = 24;
@@ -317,7 +317,7 @@
             // gotoform2button
             // 
             gotoform2button.ForeColor = SystemColors.Desktop;
-            gotoform2button.Location = new Point(637, 487);
+            gotoform2button.Location = new Point(637, 527);
             gotoform2button.Name = "gotoform2button";
             gotoform2button.Size = new Size(221, 71);
             gotoform2button.TabIndex = 25;
@@ -329,7 +329,7 @@
             // 
             authenticationlabel.AutoSize = true;
             authenticationlabel.ForeColor = Color.Chartreuse;
-            authenticationlabel.Location = new Point(1118, 499);
+            authenticationlabel.Location = new Point(1118, 539);
             authenticationlabel.Name = "authenticationlabel";
             authenticationlabel.Size = new Size(211, 25);
             authenticationlabel.TabIndex = 26;

--- a/encryption cypher app/Form2.Designer.cs
+++ b/encryption cypher app/Form2.Designer.cs
@@ -52,11 +52,11 @@
             // 
             form2titlelabel.AutoSize = true;
             form2titlelabel.ForeColor = SystemColors.Control;
-            form2titlelabel.Location = new Point(408, 9);
+            form2titlelabel.Location = new Point(400, 20);
             form2titlelabel.Name = "form2titlelabel";
             form2titlelabel.Size = new Size(238, 25);
             form2titlelabel.TabIndex = 0;
-            form2titlelabel.Text = "Random Number Generator!";
+            form2titlelabel.Text = "Key Generation & File Tools";
             // 
             // form2close
             // 
@@ -72,7 +72,7 @@
             //
             labelTotalChars.AutoSize = true;
             labelTotalChars.ForeColor = SystemColors.Control;
-            labelTotalChars.Location = new Point(82, 62);
+            labelTotalChars.Location = new Point(80, 80);
             labelTotalChars.Name = "labelTotalChars";
             labelTotalChars.Size = new Size(200, 25);
             labelTotalChars.TabIndex = 2;
@@ -80,7 +80,7 @@
             //
             // textboxTotalChars
             //
-            textboxTotalChars.Location = new Point(82, 90);
+            textboxTotalChars.Location = new Point(80, 110);
             textboxTotalChars.Name = "textboxTotalChars";
             textboxTotalChars.Size = new Size(120, 31);
             textboxTotalChars.TabIndex = 3;
@@ -90,7 +90,7 @@
             //
             labelNumNumbers.AutoSize = true;
             labelNumNumbers.ForeColor = SystemColors.Control;
-            labelNumNumbers.Location = new Point(82, 140);
+            labelNumNumbers.Location = new Point(80, 160);
             labelNumNumbers.Name = "labelNumNumbers";
             labelNumNumbers.Size = new Size(180, 25);
             labelNumNumbers.TabIndex = 4;
@@ -98,7 +98,7 @@
             //
             // textboxNumNumbers
             //
-            textboxNumNumbers.Location = new Point(82, 168);
+            textboxNumNumbers.Location = new Point(80, 190);
             textboxNumNumbers.Name = "textboxNumNumbers";
             textboxNumNumbers.Size = new Size(120, 31);
             textboxNumNumbers.TabIndex = 5;
@@ -108,7 +108,7 @@
             //
             labelNumSpecial.AutoSize = true;
             labelNumSpecial.ForeColor = SystemColors.Control;
-            labelNumSpecial.Location = new Point(82, 218);
+            labelNumSpecial.Location = new Point(80, 240);
             labelNumSpecial.Name = "labelNumSpecial";
             labelNumSpecial.Size = new Size(240, 25);
             labelNumSpecial.TabIndex = 6;
@@ -116,7 +116,7 @@
             //
             // textboxNumSpecial
             //
-            textboxNumSpecial.Location = new Point(82, 246);
+            textboxNumSpecial.Location = new Point(80, 270);
             textboxNumSpecial.Name = "textboxNumSpecial";
             textboxNumSpecial.Size = new Size(120, 31);
             textboxNumSpecial.TabIndex = 7;
@@ -124,7 +124,7 @@
             //
             // randomnisekeyvaluebutton
             //
-            randomnisekeyvaluebutton.Location = new Point(82, 300);
+            randomnisekeyvaluebutton.Location = new Point(80, 320);
             randomnisekeyvaluebutton.Name = "randomnisekeyvaluebutton";
             randomnisekeyvaluebutton.Size = new Size(120, 34);
             randomnisekeyvaluebutton.TabIndex = 8;
@@ -136,7 +136,7 @@
             //
             randomiserror.AutoSize = true;
             randomiserror.ForeColor = Color.Red;
-            randomiserror.Location = new Point(82, 345);
+            randomiserror.Location = new Point(80, 370);
             randomiserror.Name = "randomiserror";
             randomiserror.Size = new Size(309, 25);
             randomiserror.TabIndex = 9;
@@ -147,7 +147,7 @@
             //
             hideKeysCheckbox.AutoSize = true;
             hideKeysCheckbox.ForeColor = SystemColors.ButtonFace;
-            hideKeysCheckbox.Location = new Point(891, 139);
+            hideKeysCheckbox.Location = new Point(450, 320);
             hideKeysCheckbox.Name = "hideKeysCheckbox";
             hideKeysCheckbox.Size = new Size(116, 29);
             hideKeysCheckbox.TabIndex = 10;
@@ -157,7 +157,7 @@
             // 
             // EncryptFileButton
             // 
-            EncryptFileButton.Location = new Point(82, 355);
+            EncryptFileButton.Location = new Point(450, 80);
             EncryptFileButton.Name = "EncryptFileButton";
             EncryptFileButton.Size = new Size(139, 38);
             EncryptFileButton.TabIndex = 11;
@@ -167,7 +167,7 @@
             // 
             // DecryptFileButton
             // 
-            DecryptFileButton.Location = new Point(82, 413);
+            DecryptFileButton.Location = new Point(450, 140);
             DecryptFileButton.Name = "DecryptFileButton";
             DecryptFileButton.Size = new Size(139, 38);
             DecryptFileButton.TabIndex = 12;
@@ -177,7 +177,7 @@
             //
             // ExportKeysButton
             //
-            ExportKeysButton.Location = new Point(82, 471);
+            ExportKeysButton.Location = new Point(450, 200);
             ExportKeysButton.Name = "ExportKeysButton";
             ExportKeysButton.Size = new Size(139, 38);
             ExportKeysButton.TabIndex = 14;
@@ -187,7 +187,7 @@
             //
             // ImportKeysButton
             //
-            ImportKeysButton.Location = new Point(82, 529);
+            ImportKeysButton.Location = new Point(450, 260);
             ImportKeysButton.Name = "ImportKeysButton";
             ImportKeysButton.Size = new Size(139, 38);
             ImportKeysButton.TabIndex = 15;
@@ -208,7 +208,7 @@
             // 
             // fileProgressBar
             //
-            fileProgressBar.Location = new Point(270, 355);
+            fileProgressBar.Location = new Point(450, 370);
             fileProgressBar.Name = "fileProgressBar";
             fileProgressBar.Size = new Size(580, 38);
             fileProgressBar.TabIndex = 16;
@@ -218,7 +218,7 @@
             //
             statusLabel.AutoSize = true;
             statusLabel.ForeColor = SystemColors.Control;
-            statusLabel.Location = new Point(270, 413);
+            statusLabel.Location = new Point(450, 420);
             statusLabel.Name = "statusLabel";
             statusLabel.Size = new Size(0, 25);
             statusLabel.TabIndex = 17;


### PR DESCRIPTION
This task involved fixing reported UI overlaps where error text was obscuring buttons in the secondary window (Form2). I identified a direct overlap in Form2 and tight spacing in Form1. 

To solve this, I reorganized Form2 into a logical two-column structure, separating parameters from actions, which naturally cleared the overlap. I also applied preventative spacing adjustments to Form1 to accommodate dynamic error labels. All changes were verified by building the project and programmatically checking the control coordinates in the designer files. Additionally, I recorded the UX learnings regarding UI grouping and clearance in the project's palette journal.

Fixes #7

---
*PR created automatically by Jules for task [2932480857276322349](https://jules.google.com/task/2932480857276322349) started by @UnicornGod117*